### PR TITLE
Ensure that CachePadded has high alignment.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@
 #![feature(box_raw)]
 #![feature(const_fn)]
 #![feature(optin_builtin_traits)]
+#![feature(repr_simd)]
 
 extern crate alloc;
 


### PR DESCRIPTION
32-bit linux had some types where the alignment of `CachedPadded<T>` was
less than that of T, causing tests to fail and possible problems.