### PR TITLE
Relax mem ordering more when exiting a crit. sect.

### DIFF
--- a/src/mem/epoch/participant.rs
+++ b/src/mem/epoch/participant.rs
@@ -64,7 +64,7 @@ impl Participant {
         let new_count = self.in_critical.load(Relaxed) - 1;
         self.in_critical.store(
             new_count,
-            if new_count > 1 { Relaxed } else { Release });
+            if new_count > 0 { Relaxed } else { Release });
     }
 
     /// Begin the reclamation process for a piece of data.


### PR DESCRIPTION
Dear Aaron,

- I am new to this library, so my understanding of the memory orderings used in this library may be flawed, and this PR may introduce a bug. Could you possibly review this PR?
- I would to like check the correctness by testing, but I don't know how to do benchmark. What can I do before submitting PR to ensure the PR's correctness?

Thank you,
Jeehoon

--

When exiting a critical section, `in_critical`, which tracks the number
of reentrants, is decremented.  Originally, the memory ordering of the
decrement was Release if the decremented value is bigger than 1, but
this commit changes the threshold to 0.  This is because the only reason
for the Release ordering is for `try_collect` to see the change, but it
only distinguishes nonzero values from the zero.