### PR TITLE
Fix small typos in documentation

### DIFF
--- a/src/sync/ms_queue.rs
+++ b/src/sync/ms_queue.rs
@@ -18,7 +18,7 @@ struct Node<T> {
 }
 
 impl<T> MsQueue<T> {
-    /// Create a enw, emtpy queue.
+    /// Create a new, empty queue.
     pub fn new() -> MsQueue<T> {
         let q = MsQueue {
             head: CachePadded::new(Atomic::null()),

--- a/src/sync/seg_queue.rs
+++ b/src/sync/seg_queue.rs
@@ -40,7 +40,7 @@ impl<T> Segment<T> {
 }
 
 impl<T> SegQueue<T> {
-    /// Create a enw, emtpy queue.
+    /// Create a new, empty queue.
     pub fn new() -> SegQueue<T> {
         let q = SegQueue {
             head: Atomic::null(),


### PR DESCRIPTION
Noticed two typos when reading the docs, so this is a small PR to fix them up. Thanks for making an awesome crate!