### PR TITLE
DOC: Fix some typos

### DIFF
--- a/src/sync/ms_queue.rs
+++ b/src/sync/ms_queue.rs
@@ -18,7 +18,7 @@ struct Node<T> {
 }
 
 impl<T> MsQueue<T> {
-    /// Create a enw, emtpy queue.
+    /// Create a new, empty queue.
     pub fn new() -> MsQueue<T> {
         let q = MsQueue {
             head: CachePadded::new(Atomic::null()),


### PR DESCRIPTION
Was someone typing in parallel? The result seems to be out of order... :stuck_out_tongue_closed_eyes: 