### PR TITLE
Relax T: Sync for MsQueue<T>: Send/Sync, and add T: Send for SegQueue.

### DIFF
--- a/src/sync/ms_queue.rs
+++ b/src/sync/ms_queue.rs
@@ -46,10 +46,10 @@ impl<T> Node<T> {
     }
 }
 
-// FIXME: Stay on the safe side for now, requiring both `Send` and
-// `Sync` in all cases.
-unsafe impl<T: Send + Sync> Sync for MsQueue<T> {}
-unsafe impl<T: Send + Sync> Send for MsQueue<T> {}
+// Any particular `T` should never accessed concurrently, so no need
+// for Sync.
+unsafe impl<T: Send> Sync for MsQueue<T> {}
+unsafe impl<T: Send> Send for MsQueue<T> {}
 
 impl<T> MsQueue<T> {
     /// Create a new, empty queue.

--- a/src/sync/seg_queue.rs
+++ b/src/sync/seg_queue.rs
@@ -25,7 +25,7 @@ struct Segment<T> {
     next: Atomic<Segment<T>>,
 }
 
-unsafe impl<T> Sync for Segment<T> {}
+unsafe impl<T: Send> Sync for Segment<T> {}
 
 impl<T> Segment<T> {
     fn new() -> Segment<T> {


### PR DESCRIPTION
The latter is particularly important, as previously SegQueue would allow
sending, e.g., Rc<_> across threads.