### PR TITLE
Fixing race condition in garbage collection

### DIFF
--- a/src/mem/epoch/garbage.rs
+++ b/src/mem/epoch/garbage.rs
@@ -9,7 +9,7 @@
 use std::ptr;
 use std::mem;
 use std::sync::atomic::AtomicPtr;
-use std::sync::atomic::Ordering::{Relaxed, Release};
+use std::sync::atomic::Ordering::{Relaxed, Release, Acquire};
 
 use mem::ZerosValid;
 
@@ -124,13 +124,17 @@ impl ConcBag {
     }
 
     pub unsafe fn collect(&self) {
+        // check to avoid xchg instruction
+        // when no garbage exists
         let mut head = self.head.load(Relaxed);
-        self.head.store(ptr::null_mut(), Relaxed);
+        if head != ptr::null_mut() {
+            head = self.head.swap(ptr::null_mut(), Acquire);
 
-        while head != ptr::null_mut() {
-            let mut n = Box::from_raw(head);
-            n.data.collect();
-            head = n.next.load(Relaxed);
+            while head != ptr::null_mut() {
+                let mut n = Box::from_raw(head);
+                n.data.collect();
+                head = n.next.load(Relaxed);
+            }
         }
     }
 }


### PR DESCRIPTION
The collect function in ConcBag is unsound - it's possible for a thread inserting into the linked list at the same time a thread enters collect to make an insertion that isn't visible. This happens when the collecting thread loads head (previously line 127), then thread b successfully completes the CAS to update head (line 122), then the collecting thread stores nullptr to head (previously line 128) and continues using a stale value for head. Moving to an atomic swap means that the CAS will not race with the store - either the CAS will complete first and that value will be visible in the swap, or the swap will complete first and the CAS will fail.

A similar issue happens when two threads attempt to collect at the same time, and is fixed by this as well.