### PR TITLE
Add Rust 1.2.0 compatiblity

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,25 @@ impl<F: FnOnce()> FnBox for F {
     fn call_box(self: Box<Self>) { (*self)() }
 }
 
+// TODO: Remove once Cargo no longer wants to build on Rust 1.2.0.
+trait BoxExt {
+    type T;
+    fn into_raw_(s: Self) -> *mut Self::T;
+    unsafe fn from_raw_(t: *mut Self::T) -> Self;
+}
+
+impl<T> BoxExt for Box<T> {
+    type T = T;
+    fn into_raw_(b: Box<T>) -> *mut T {
+        unsafe {
+            std::mem::transmute(b)
+        }
+    }
+    unsafe fn from_raw_(t: *mut T) -> Box<T> {
+        std::mem::transmute(t)
+    }
+}
+
 /// Like `std::thread::spawn`, but without the closure bounds.
 pub unsafe fn spawn_unsafe<'a, F>(f: F) -> thread::JoinHandle<()> where F: FnOnce() + 'a {
     use std::mem;

--- a/src/mem/epoch/garbage.rs
+++ b/src/mem/epoch/garbage.rs
@@ -12,6 +12,7 @@ use std::sync::atomic::AtomicPtr;
 use std::sync::atomic::Ordering::{Relaxed, Release};
 
 use mem::ZerosValid;
+use BoxExt;
 
 /// One item of garbage.
 ///
@@ -114,7 +115,7 @@ struct Node {
 
 impl ConcBag {
     pub fn insert(&self, t: Bag){
-        let n = Box::into_raw(Box::new(
+        let n = Box::into_raw_(Box::new(
             Node { data: t, next: AtomicPtr::new(ptr::null_mut()) }));
         loop {
             let head = self.head.load(Relaxed);
@@ -128,7 +129,7 @@ impl ConcBag {
         self.head.store(ptr::null_mut(), Relaxed);
 
         while head != ptr::null_mut() {
-            let mut n = Box::from_raw(head);
+            let mut n = Box::from_raw_(head);
             n.data.collect();
             head = n.next.load(Relaxed);
         }

--- a/src/mem/epoch/global.rs
+++ b/src/mem/epoch/global.rs
@@ -34,6 +34,7 @@ mod imp {
     use super::EpochState;
     use mem::CachePadded;
     use mem::epoch::participants::Participants;
+    use BoxExt;
 
     impl EpochState {
         fn new() -> EpochState {
@@ -54,11 +55,11 @@ mod imp {
 
         if addr == 0 {
             let boxed = Box::new(EpochState::new());
-            let raw = Box::into_raw(boxed);
+            let raw = Box::into_raw_(boxed);
 
             addr = EPOCH.compare_and_swap(0, raw as usize, Relaxed);
             if addr != 0 {
-                let boxed = unsafe { Box::from_raw(raw) };
+                let boxed = unsafe { Box::from_raw_(raw) };
                 mem::drop(boxed);
             } else {
                 addr = raw as usize;

--- a/src/sync/atomic_option.rs
+++ b/src/sync/atomic_option.rs
@@ -1,6 +1,8 @@
 use std::sync::atomic::{AtomicPtr, Ordering};
 use std::ptr;
 
+use BoxExt;
+
 unsafe impl<T: Send> Send for AtomicOption<T> {}
 unsafe impl<T: Send> Sync for AtomicOption<T> {}
 
@@ -18,13 +20,13 @@ impl<T> AtomicOption<T> {
         if old.is_null() {
             None
         } else {
-            Some(unsafe { Box::from_raw(old) })
+            Some(unsafe { Box::from_raw_(old) })
         }
     }
 
     // allows re-use of allocation
     pub fn swap_box(&self, t: Box<T>, order: Ordering) -> Option<Box<T>> {
-        self.swap_inner(Box::into_raw(t), order)
+        self.swap_inner(Box::into_raw_(t), order)
     }
 
     pub fn swap(&self, t: T, order: Ordering) -> Option<T> {


### PR DESCRIPTION
This would allow Cargo to build on 1.2.0 again: https://github.com/rust-lang/cargo/pull/2297#issuecomment-174617125.