### PR TITLE
Relax the requirements for `Deque<T>` to be `Send` and `Sync`.

### DIFF
--- a/src/sync/chase_lev.rs
+++ b/src/sync/chase_lev.rs
@@ -64,8 +64,8 @@ struct Deque<T> {
 }
 
 // FIXME: can these constraints be relaxed?
-unsafe impl<T: Send + Sync> Send for Deque<T> {}
-unsafe impl<T: Send + Sync> Sync for Deque<T> {}
+unsafe impl<T: Send> Send for Deque<T> {}
+unsafe impl<T: Send> Sync for Deque<T> {}
 
 /// Worker half of the work-stealing deque. This worker has exclusive access to
 /// one side of the deque, and uses `push` and `try_pop` method to manipulate it.


### PR DESCRIPTION
The old `std::sync::deque` module, and the `deque` crate descended from it, require only that `T` implement `Send` in order for `Deque<T>` to implement `Send` and `Sync`. This crate's `chase_lev` module, however, currently requires `T` also to be `Sync`, making this example fail to compile.

    #![feature(optin_builtin_traits)]

    extern crate crossbeam;
    extern crate deque;

    use std::thread;

    struct Unsynced;

    impl !Sync for Unsynced { }

    #[test]
    fn deque_crate_unsynced() {
        use deque;

        let (worker, stealer) = deque::new();
        let handle = thread::spawn(move || {
            loop {
                match stealer.steal() {
                    deque::Stolen::Data(_) => {
                        break;
                    }
                    _ => {}
                }
            }
        });
        worker.push(Unsynced);
        handle.join().unwrap();
    }

    #[test]
    fn chase_lev_mod_unsynced() {
        use crossbeam::sync::chase_lev;

        let (mut worker, stealer) = chase_lev::deque();
        let handle = thread::spawn(move || {
            loop {
                match stealer.steal() {
                    chase_lev::Steal::Data(_) => {
                        break;
                    }
                    _ => {}
                }
            }
        });
        worker.push(Unsynced);
        handle.join().unwrap();
    }

Intuitively, this makes sense to me: each element has a clear ownership path from the originating thread, to the deque, and finally to the stealing thread.