### PR TITLE
Fix bugs preventing memory reclamation

### DIFF
--- a/src/mem/epoch/garbage.rs
+++ b/src/mem/epoch/garbage.rs
@@ -94,7 +94,7 @@ impl Local {
     }
 
     pub fn size(&self) -> usize {
-        self.old.len() + self.cur.len()
+        self.old.len() + self.cur.len() + self.new.len()
     }
 }
 

--- a/src/mem/epoch/participant.rs
+++ b/src/mem/epoch/participant.rs
@@ -25,6 +25,10 @@ pub struct Participant {
     /// is ultimately used to free `Participant` records.
     pub active: AtomicBool,
 
+    /// Has the thread been passed to unlinked() yet?
+    /// Used to avoid a double free when reclaiming participants.
+    pub unlinked: AtomicBool,
+
     /// The participant list is coded intrusively; here's the `next` pointer.
     pub next: Atomic<ParticipantNode>,
 }
@@ -37,6 +41,7 @@ impl Participant {
             epoch: AtomicUsize::new(0),
             in_critical: AtomicUsize::new(0),
             active: AtomicBool::new(true),
+            unlinked: AtomicBool::new(false),
             garbage: UnsafeCell::new(garbage::Local::new()),
             next: Atomic::null(),
         }

--- a/src/mem/epoch/participant.rs
+++ b/src/mem/epoch/participant.rs
@@ -93,6 +93,7 @@ impl Participant {
         self.epoch.store(new_epoch, Relaxed);
 
         unsafe {
+            (*self.garbage.get()).collect();
             global::get().garbage[new_epoch.wrapping_add(1) % 3].collect();
         }
 

--- a/src/mem/epoch/participants.rs
+++ b/src/mem/epoch/participants.rs
@@ -110,7 +110,6 @@ impl<'a> Iterator for Iter<'a> {
                         self.guard.unlinked(n)
                     }
                 }
-                self.next = &n.next;
             } else {
                 self.next = &n.next;
                 return Some(&n)

--- a/src/mem/epoch/participants.rs
+++ b/src/mem/epoch/participants.rs
@@ -107,7 +107,16 @@ impl<'a> Iterator for Iter<'a> {
                 cur = n.next.load(Relaxed, self.guard);
                 unsafe {
                     if self.next.cas_shared(Some(n), cur, Relaxed) {
-                        self.guard.unlinked(n)
+                        // Having succesfully disconnected n from our
+                        // current node doesn't guarantee that n is
+                        // totally disconnected from the list: the
+                        // node that self.next lies in may have itself
+                        // been disconnected from the list. Thus, do a
+                        // CAS against unlinked to make sure we only
+                        // unlink a node once.
+                        if n.unlinked.compare_and_swap(false, true, Relaxed) {
+                            self.guard.unlinked(n);
+                        }
                     }
                 }
             } else {


### PR DESCRIPTION
Fix two bugs that were preventing memory reclamation from occurring and another bug exposed by reclaiming the memory.

In my brief testing, performance impact is fairly small (and positive sometimes?). Might be worth regenerating the doc graphs anyways, though?