### PR TITLE
Added checks to garbage migration to avoid extra work

### DIFF
--- a/src/mem/epoch/garbage.rs
+++ b/src/mem/epoch/garbage.rs
@@ -114,6 +114,9 @@ struct Node {
 
 impl ConcBag {
     pub fn insert(&self, t: Bag){
+        if t.len() == 0 {
+            return //don't insert an empty bag
+        }
         let n = Box::into_raw(Box::new(
             Node { data: t, next: AtomicPtr::new(ptr::null_mut()) }));
         loop {

--- a/src/mem/epoch/participant.rs
+++ b/src/mem/epoch/participant.rs
@@ -107,6 +107,9 @@ impl Participant {
 
     /// Move the current thread-local garbage into the global garbage bags.
     pub fn migrate_garbage(&self) {
+        if self.garbage_size() == 0 {
+            return //skip resetting bags in there's nothing in them
+        }
         let cur_epoch = self.epoch.load(Relaxed);
         let local = unsafe { mem::replace(&mut *self.garbage.get(), garbage::Local::new()) };
         global::get().garbage[cur_epoch.wrapping_sub(1) % 3].insert(local.old);


### PR DESCRIPTION
This will prevent the global bags from accepting an empty local bag, and will also stop garbage migration if there is no garbage to migrate (preventing the local collector from prematurely deallocating space in local bags)

More complex checks and paths could be added to migrate for doing checks and swaps on individual bags, but I don't know how much benefit that would bring.