### PR TITLE
Fix multiple segfault-causing bugs

### DIFF
--- a/src/mem/epoch/local.rs
+++ b/src/mem/epoch/local.rs
@@ -22,11 +22,7 @@ impl LocalEpoch {
 // FIXME: avoid leaking when all threads have exited
 impl Drop for LocalEpoch {
     fn drop(&mut self) {
-        let p = self.get();
-        p.enter();
-        p.migrate_garbage();
-        p.exit();
-        p.active.store(false, Relaxed);
+        self.get().active.store(false, Relaxed);
     }
 }
 

--- a/src/mem/epoch/participants.rs
+++ b/src/mem/epoch/participants.rs
@@ -105,20 +105,7 @@ impl<'a> Iterator for Iter<'a> {
             // attempt to clean up inactive nodes
             if !n.active.load(Relaxed) {
                 cur = n.next.load(Relaxed, self.guard);
-                unsafe {
-                    if self.next.cas_shared(Some(n), cur, Relaxed) {
-                        // Having succesfully disconnected n from our
-                        // current node doesn't guarantee that n is
-                        // totally disconnected from the list: the
-                        // node that self.next lies in may have itself
-                        // been disconnected from the list. Thus, do a
-                        // CAS against unlinked to make sure we only
-                        // unlink a node once.
-                        if n.unlinked.compare_and_swap(false, true, Relaxed) {
-                            self.guard.unlinked(n);
-                        }
-                    }
-                }
+                // TODO: actually reclaim inactive participants!
             } else {
                 self.next = &n.next;
                 return Some(&n)


### PR DESCRIPTION
This commit closes two major holes, one related to the use of local
garbage bags, and the other to reclaiming participant data from exited
threads. After making these changes, I am no longer able to reproduce
segfaults or assertion failures. (I had previously build some aggressive
testing that was able to consistently segfault in a few seconds on every try.)

The use of local bags was creating a problem in which garbage could be
collected too early. It's crucial that when `unlinked` is called, the
data to be reclaimed is associated with the *current global
epoch* (and **not** the current local snapshot of the epoch). The reason
is that other threads may have outstanding pointers to the data, and may
be an epoch ahead; when the thread calling `unlinked` unpins, the epoch
could move forward again, causing the `unlinked` data to be collected
while pointers to it remain.

I was aware of this issue with the epoch algorithm, but Crossbeam
attempted to optimize things by using local bags of garbage nodes. These
local bags, however, did not manage to avoid the above problem.

This commit reverts the use of local bags (which has caused other
problems), returning to something closer to the original epoch algorithm
for the time being.

There was also a bug in freeing participant data from threads that have
exited after being involved in epoch management -- essentially, the code
removing a node from the middle of a linked-list was subject to race
conditions in which a previously-`unlinked` node could suddenly
reappear.

For the time being, I have simply removed all reclamation of participant
nodes. This is a memory leak, but a rather small one: it's proportional
to the number of threads that have ever used epochs and have since
terminated.

In a follow-up PR, I will try to roll out a working algorithm for
participant reclamation, likely based on marked pointers.

r? @alexcrichton