### PR TITLE
Fixed direct assignment to uninitialized memory

### DIFF
--- a/src/sync/seg_queue.rs
+++ b/src/sync/seg_queue.rs
@@ -62,7 +62,7 @@ impl<T> SegQueue<T> {
             let i = tail.high.fetch_add(1, Relaxed);
             unsafe {
                 if i < SEG_SIZE {
-                    *(*tail).data.get_unchecked(i).get() = t;
+                    ptr::write((*tail).data.get_unchecked(i).get(), t);
                     tail.ready.get_unchecked(i).store(true, Release);
 
                     if i + 1 == SEG_SIZE {


### PR DESCRIPTION
This removes a direct assignment to uninitialized memory. The assignment causes the program to try and drop the variable, which can cause issues - see #44 for an example.