### PR TITLE
Made it so that all producers in SegQueue will try to extend tail

### DIFF
--- a/src/sync/seg_queue.rs
+++ b/src/sync/seg_queue.rs
@@ -4,9 +4,11 @@ use std::{ptr, mem};
 use std::cmp;
 use std::cell::UnsafeCell;
 
-use mem::epoch::{self, Atomic, Owned};
+use mem::epoch::{self, Atomic, Owned, Shared, Guard};
 
 const SEG_SIZE: usize = 32;
+const MAX_TRIES: usize = 6;
+const MIN_TRIES: usize = 1;
 
 /// A Michael-Scott queue that allocates "segments" (arrays of nodes)
 /// for efficiency.
@@ -53,9 +55,19 @@ impl<T> SegQueue<T> {
         q
     }
 
+    #[inline(always)]
+    fn try_add_tail(&self, t: &Shared<Segment<T>>, g: &Guard) {
+        let seg = Owned::new(Segment::new());
+        if let Ok(newptr) = t.next.cas_and_ref(None, seg, Release, &g) {
+            self.tail.store_shared(Some(newptr), Release);
+        }
+    }
+
     /// Add `t` to the back of the queue.
     pub fn push(&self, t: T) {
         let guard = epoch::pin();
+        let mut j = 0;
+        let mut cur_tries = MAX_TRIES;
         loop {
             let tail = self.tail.load(Acquire, &guard).unwrap();
             if tail.high.load(Relaxed) >= SEG_SIZE { continue }
@@ -66,12 +78,20 @@ impl<T> SegQueue<T> {
                     tail.ready.get_unchecked(i).store(true, Release);
 
                     if i + 1 == SEG_SIZE {
-                        let tail = tail.next.store_and_ref(Owned::new(Segment::new()), Release, &guard);
-                        self.tail.store_shared(Some(tail), Release);
+                        self.try_add_tail(&tail, &guard);
                     }
 
                     return
                 }
+            }
+            j += 1;
+            if j >= cur_tries {
+                j = 0;
+                if cur_tries > MIN_TRIES {
+                    cur_tries = (11 * cur_tries)/16;
+                    cur_tries = cmp::max(cur_tries, MIN_TRIES);
+                }
+                self.try_add_tail(&tail, &guard);
             }
         }
     }


### PR DESCRIPTION
This makes it so that any producer trying to push into the SegQueue can extend the tail if the current segment is full and the thread that filled the last element is stuck, or takes a long time to allocate, or for whatever reason takes a long time to extend the queue. Producers will try more and more frequently to update the tail to statistically lower the upper bound.

A producer can still block, but the window is far smaller -  it would have to get preempted between lines 61 and 62, which is a very small range and unlikely.

According to bench.rs, this doesn't really have a performance impact - if it did, it was within measuring variance.

This seems like a use case for a sort of mcas, since I think that would make it possible to perform this operation in a fashion where no thread could block producers - @aturon, do you think this would make sense, and could be implemented in a somewhat performant fashion in Rust? I'm not very familiar with the algorithm behind it.