### PR TITLE
Don't advance the epoch in try_collect until after doing the collection.

### DIFF
--- a/src/mem/epoch/participant.rs
+++ b/src/mem/epoch/participant.rs
@@ -99,10 +99,10 @@ impl Participant {
             return false
         }
 
-        self.epoch.store(new_epoch, Relaxed);
         unsafe {
             global::get().garbage[new_epoch.wrapping_add(1) % 3].collect();
         }
+        self.epoch.store(new_epoch, Release);
         self.num_ops.set(0);
 
         true


### PR DESCRIPTION
In try_collect(), it is important to reclaim memory from two epochs
ago *before* advancing the local epoch. As soon as the local epoch has
been advanced, another thread could advance the epoch and start
putting garbage in that same bag.

Closes #46.