### PR TITLE
Re-introduce gc to seg-queue

### DIFF
--- a/src/sync/seg_queue.rs
+++ b/src/sync/seg_queue.rs
@@ -101,6 +101,7 @@ impl<T> SegQueue<T> {
                             loop {
                                 if let Some(next) = head.next.load(Acquire, &guard) {
                                     self.head.store_shared(Some(next), Release);
+                                    unsafe { guard.unlinked(head); }
                                     break
                                 }
                             }


### PR DESCRIPTION
A pull request of mine accidentally removed memory reclamation from seg_queue, this adds it back.