### PR TITLE
Align spawn_unsafe with thread::spawn by requiring Send

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ impl<F: FnOnce()> FnBox for F {
 }
 
 /// Like `std::thread::spawn`, but without the closure bounds.
-pub unsafe fn spawn_unsafe<'a, F>(f: F) -> thread::JoinHandle<()> where F: FnOnce() + 'a {
+pub unsafe fn spawn_unsafe<'a, F>(f: F) -> thread::JoinHandle<()> where F: FnOnce() + Send + 'a {
     use std::mem;
 
     let closure: Box<FnBox + 'a> = Box::new(f);


### PR DESCRIPTION
`std`'s `thead::spawn` requires the passed function to be bound by `Send` to avoid bad things like passing `UnsafeCell` between threads. The goal of `spawn_unsafe` is to remove the closure lifetime bound, but in its current version, it also removes the `Send` bound, preventing the compiler from catching a number of potential bugs. This patch adds back `Send`, and fixes #54.