### PR TITLE
Add an AtomicReference type

### DIFF
--- a/src/sync/atomic_reference.rs
+++ b/src/sync/atomic_reference.rs
@@ -1,0 +1,89 @@
+use std::marker::PhantomData;
+use std::mem;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// A type providing atomic storage and retrieval of an `Arc<T>`.
+pub struct AtomicReference<T>(AtomicUsize, PhantomData<Arc<T>>);
+
+impl<T> Drop for AtomicReference<T> {
+    fn drop(&mut self) {
+        self.take();
+    }
+}
+
+impl<T> AtomicReference<T> {
+    /// Creates a new `AtomicReference`.
+    pub fn new(t: Arc<T>) -> AtomicReference<T> {
+        AtomicReference(AtomicUsize::new(unsafe { mem::transmute(t) }), PhantomData)
+    }
+
+    fn take(&self) -> Arc<T> {
+        loop {
+            match self.0.swap(0, Ordering::Acquire) {
+                0 => {}
+                n => return unsafe { mem::transmute(n) }
+            }
+        }
+    }
+
+    fn put(&self, t: Arc<T>) {
+        debug_assert_eq!(self.0.load(Ordering::SeqCst), 0);
+        self.0.store(unsafe { mem::transmute(t) }, Ordering::Release);
+    }
+
+    /// Stores a new value in the `AtomicReference`, returning the previous
+    /// value.
+    pub fn set(&self, t: Arc<T>) -> Arc<T> {
+        let old = self.take();
+        self.put(t);
+        old
+    }
+
+    /// Returns a copy of the value stored by the `AtomicReference`.
+    pub fn get(&self) -> Arc<T> {
+        let t = self.take();
+        // NB: correctness here depends on Arc's clone impl not panicking
+        let out = t.clone();
+        self.put(t);
+        out
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
+    use std::sync::atomic::{ATOMIC_USIZE_INIT, AtomicUsize, Ordering};
+
+    use super::*;
+
+    #[test]
+    fn basic() {
+        let r = AtomicReference::new(Arc::new(0));
+        assert_eq!(*r.get(), 0);
+        assert_eq!(*r.set(Arc::new(1)), 0);
+        assert_eq!(*r.get(), 1);
+    }
+
+    #[test]
+    fn drop_runs() {
+        static DROPS: AtomicUsize = ATOMIC_USIZE_INIT;
+
+        struct Foo;
+
+        impl Drop for Foo {
+            fn drop(&mut self) {
+                DROPS.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let r = AtomicReference::new(Arc::new(Foo));
+        let _f = r.get();
+        r.get();
+        r.set(Arc::new(Foo));
+        drop(_f);
+        assert_eq!(DROPS.load(Ordering::SeqCst), 1);
+        drop(r);
+        assert_eq!(DROPS.load(Ordering::SeqCst), 2);
+    }
+}

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -4,9 +4,11 @@ pub use self::ms_queue::MsQueue;
 pub use self::atomic_option::AtomicOption;
 pub use self::treiber_stack::TreiberStack;
 pub use self::seg_queue::SegQueue;
+pub use self::atomic_reference::AtomicReference;
 
 mod atomic_option;
 mod ms_queue;
 mod treiber_stack;
 mod seg_queue;
 pub mod chase_lev;
+mod atomic_reference;

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -4,11 +4,11 @@ pub use self::ms_queue::MsQueue;
 pub use self::atomic_option::AtomicOption;
 pub use self::treiber_stack::TreiberStack;
 pub use self::seg_queue::SegQueue;
-pub use self::atomic_reference::AtomicReference;
+pub use self::arc_cell::ArcCell;
 
 mod atomic_option;
 mod ms_queue;
 mod treiber_stack;
 mod seg_queue;
 pub mod chase_lev;
-mod atomic_reference;
+mod arc_cell;


### PR DESCRIPTION
See https://github.com/sfackler/log4rs/commit/5ed2895bfe2ac92e30a4a5506bde98081bc85cce for a usage example.

I'm not sure `AtomicReference` is the right name - I stole it from Java, but we might want this to be called something else to indicate that it's tied up with `Arc`.

It's also a bit sketchy that we assume that `Arc<T>` is the same size as `usize`, but that seems preferable to defining a new smart pointer just for this.