### PR TITLE
Implement the `Debug` trait for all public types

### DIFF
--- a/src/bin/extra_impls/mpsc_queue.rs
+++ b/src/bin/extra_impls/mpsc_queue.rs
@@ -40,12 +40,14 @@
 
 pub use self::PopResult::*;
 
+use std::fmt;
 use std::ptr;
 use std::cell::UnsafeCell;
 
 use std::sync::atomic::{AtomicPtr, Ordering};
 
 /// A result of the `pop` function.
+#[derive(Debug)]
 pub enum PopResult<T> {
     /// Some data has been popped
     Data(T),
@@ -58,6 +60,7 @@ pub enum PopResult<T> {
     Inconsistent,
 }
 
+#[derive(Debug)]
 struct Node<T> {
     next: AtomicPtr<Node<T>>,
     value: Option<T>,
@@ -69,6 +72,12 @@ struct Node<T> {
 pub struct Queue<T> {
     head: AtomicPtr<Node<T>>,
     tail: UnsafeCell<*mut Node<T>>,
+}
+
+impl<T> fmt::Debug for Queue<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Queue {{ ... }}")
+    }
 }
 
 unsafe impl<T: Send> Send for Queue<T> { }

--- a/src/mem/cache_padded.rs
+++ b/src/mem/cache_padded.rs
@@ -1,5 +1,6 @@
 use std::marker;
 use std::cell::UnsafeCell;
+use std::fmt;
 use std::mem;
 use std::ptr;
 use std::ops::{Deref, DerefMut};
@@ -9,6 +10,7 @@ const CACHE_LINE: usize = 32;
 
 #[cfg_attr(feature = "nightly",
            repr(simd))]
+#[derive(Debug)]
 struct Padding(u64, u64, u64, u64);
 
 /// Pad `T` to the length of a cacheline.
@@ -26,6 +28,12 @@ struct Padding(u64, u64, u64, u64);
 pub struct CachePadded<T> {
     data: UnsafeCell<[usize; CACHE_LINE]>,
     _marker: ([Padding; 0], marker::PhantomData<T>),
+}
+
+impl<T> fmt::Debug for CachePadded<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "CachePadded {{ ... }}")
+    }
 }
 
 unsafe impl<T: Send> Send for CachePadded<T> {}

--- a/src/mem/epoch/atomic.rs
+++ b/src/mem/epoch/atomic.rs
@@ -9,6 +9,7 @@ use super::{Owned, Shared, Guard};
 ///
 /// Provides atomic access to a (nullable) pointer of type `T`, interfacing with
 /// the `Owned` and `Shared` types.
+#[derive(Debug)]
 pub struct Atomic<T> {
     ptr: atomic::AtomicPtr<T>,
     _marker: PhantomData<*const ()>,

--- a/src/mem/epoch/garbage.rs
+++ b/src/mem/epoch/garbage.rs
@@ -16,12 +16,14 @@ use mem::ZerosValid;
 /// One item of garbage.
 ///
 /// Stores enough information to do a deallocation.
+#[derive(Debug)]
 struct Item {
     ptr: *mut u8,
     free: unsafe fn(*mut u8),
 }
 
 /// A single, thread-local bag of garbage.
+#[derive(Debug)]
 pub struct Bag(Vec<Item>);
 
 impl Bag {
@@ -62,6 +64,7 @@ unsafe impl Send for Bag {}
 unsafe impl Sync for Bag {}
 
 /// A thread-local set of garbage bags.
+#[derive(Debug)]
 pub struct Local {
     /// Garbage added at least one epoch behind the current local epoch
     pub old: Bag,
@@ -100,12 +103,14 @@ impl Local {
 /// A concurrent garbage bag, currently based on Treiber's stack.
 ///
 /// The elements are themselves owned `Bag`s.
+#[derive(Debug)]
 pub struct ConcBag {
     head: AtomicPtr<Node>,
 }
 
 unsafe impl ZerosValid for ConcBag {}
 
+#[derive(Debug)]
 struct Node {
     data: Bag,
     next: AtomicPtr<Node>,

--- a/src/mem/epoch/global.rs
+++ b/src/mem/epoch/global.rs
@@ -8,6 +8,7 @@ use mem::epoch::garbage;
 use mem::epoch::participants::Participants;
 
 /// Global epoch state
+#[derive(Debug)]
 pub struct EpochState {
     /// Current global epoch
     pub epoch: CachePadded<AtomicUsize>,

--- a/src/mem/epoch/guard.rs
+++ b/src/mem/epoch/guard.rs
@@ -7,6 +7,7 @@ use super::{local, Shared};
 /// A guard must be acquired before most operations on an `Atomic` pointer. On
 /// destruction, it unpins the epoch.
 #[must_use]
+#[derive(Debug)]
 pub struct Guard {
     _marker: marker::PhantomData<*mut ()>, // !Send and !Sync
 }

--- a/src/mem/epoch/local.rs
+++ b/src/mem/epoch/local.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::Ordering::Relaxed;
 use mem::epoch::participant::Participant;
 use mem::epoch::global;
 
+#[derive(Debug)]
 struct LocalEpoch {
     participant: *const Participant,
 }

--- a/src/mem/epoch/mod.rs
+++ b/src/mem/epoch/mod.rs
@@ -142,6 +142,7 @@ use std::ptr;
 use std::mem;
 
 /// Like `Box<T>`: an owned, heap-allocated data value of type `T`.
+#[derive(Debug)]
 pub struct Owned<T> {
     data: Box<T>,
 }
@@ -177,6 +178,7 @@ impl<T> DerefMut for Owned<T> {
 
 #[derive(PartialEq, Eq)]
 /// Like `&'a T`: a shared reference valid for lifetime `'a`.
+#[derive(Debug)]
 pub struct Shared<'a, T: 'a> {
     data: &'a T,
 }

--- a/src/mem/epoch/participant.rs
+++ b/src/mem/epoch/participant.rs
@@ -3,6 +3,7 @@
 
 use std::mem;
 use std::cell::UnsafeCell;
+use std::fmt;
 use std::sync::atomic::{self, AtomicUsize, AtomicBool};
 use std::sync::atomic::Ordering::{Relaxed, Acquire, Release, SeqCst};
 
@@ -27,6 +28,12 @@ pub struct Participant {
 
     /// The participant list is coded intrusively; here's the `next` pointer.
     pub next: Atomic<ParticipantNode>,
+}
+
+impl fmt::Debug for Participant {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Participant {{ ... }}")
+    }
 }
 
 unsafe impl Sync for Participant {}

--- a/src/mem/epoch/participants.rs
+++ b/src/mem/epoch/participants.rs
@@ -11,10 +11,12 @@ use mem::epoch::participant::Participant;
 use mem::CachePadded;
 
 /// Global, threadsafe list of threads participating in epoch management.
+#[derive(Debug)]
 pub struct Participants {
     head: Atomic<ParticipantNode>
 }
 
+#[derive(Debug)]
 pub struct ParticipantNode(CachePadded<Participant>);
 
 impl ParticipantNode {
@@ -81,6 +83,7 @@ impl Participants {
     }
 }
 
+#[derive(Debug)]
 pub struct Iter<'a> {
     // pin to an epoch so that we can free inactive nodes
     guard: &'a Guard,

--- a/src/scoped.rs
+++ b/src/scoped.rs
@@ -1,4 +1,5 @@
 use std::cell::RefCell;
+use std::fmt;
 use std::mem;
 use std::rc::Rc;
 use std::sync::atomic::Ordering;
@@ -61,6 +62,18 @@ pub fn scope<'a, F, R>(f: F) -> R where F: FnOnce(&Scope<'a>) -> R {
     let ret = f(&scope);
     scope.drop_all();
     ret
+}
+
+impl<'a> fmt::Debug for Scope<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Scope {{ ... }}")
+    }
+}
+
+impl<T> fmt::Debug for ScopedJoinHandle<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "ScopedJoinHandle {{ ... }}")
+    }
 }
 
 impl<'a> Scope<'a> {

--- a/src/sync/arc_cell.rs
+++ b/src/sync/arc_cell.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// A type providing atomic storage and retrieval of an `Arc<T>`.
+#[derive(Debug)]
 pub struct ArcCell<T>(AtomicUsize, PhantomData<Arc<T>>);
 
 impl<T> Drop for ArcCell<T> {

--- a/src/sync/atomic_option.rs
+++ b/src/sync/atomic_option.rs
@@ -4,6 +4,7 @@ use std::ptr;
 unsafe impl<T: Send> Send for AtomicOption<T> {}
 unsafe impl<T: Send> Sync for AtomicOption<T> {}
 
+#[derive(Debug)]
 pub struct AtomicOption<T> {
     inner: AtomicPtr<T>,
 }

--- a/src/sync/chase_lev.rs
+++ b/src/sync/chase_lev.rs
@@ -39,6 +39,7 @@
 //! [weak_chase_lev]: http://www.di.ens.fr/~zappa/readings/ppopp13.pdf
 
 use std::cell::UnsafeCell;
+use std::fmt;
 use std::mem;
 use std::ptr;
 use std::sync::atomic::Ordering::{Acquire, Relaxed, Release, SeqCst};
@@ -58,6 +59,7 @@ const K: isize = 4;
 // The size in question is 1 << MIN_BITS
 const MIN_BITS: u32 = 7;
 
+#[derive(Debug)]
 struct Deque<T> {
     bottom: AtomicIsize,
     top: AtomicIsize,
@@ -73,6 +75,7 @@ unsafe impl<T: Send> Sync for Deque<T> {}
 ///
 /// There may only be one worker per deque, and operations on the worker
 /// require mutable access to the worker itself.
+#[derive(Debug)]
 pub struct Worker<T> {
     deque: Arc<Deque<T>>,
 }
@@ -82,6 +85,7 @@ pub struct Worker<T> {
 /// `steal` method.
 ///
 /// Stealers can be cloned to have more than one handle active at a time.
+#[derive(Debug)]
 pub struct Stealer<T> {
     deque: Arc<Deque<T>>,
 }
@@ -107,6 +111,12 @@ pub enum Steal<T> {
 struct Buffer<T> {
     storage: UnsafeCell<Vec<T>>,
     log_size: u32,
+}
+
+impl<T> fmt::Debug for Buffer<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Buffer {{ ... }}")
+    }
 }
 
 impl<T> Worker<T> {

--- a/src/sync/ms_queue.rs
+++ b/src/sync/ms_queue.rs
@@ -13,16 +13,19 @@ use mem::CachePadded;
 // node at the front. In general the `tail` pointer may lag behind the
 // actual tail. Non-sentinal nodes are either all `Data` or all
 // `Blocked` (requests for data from blocked threads).
+#[derive(Debug)]
 pub struct MsQueue<T> {
     head: CachePadded<Atomic<Node<T>>>,
     tail: CachePadded<Atomic<Node<T>>>,
 }
 
+#[derive(Debug)]
 struct Node<T> {
     payload: Payload<T>,
     next: Atomic<Node<T>>,
 }
 
+#[derive(Debug)]
 enum Payload<T> {
     /// A node with actual data that can be popped.
     Data(T),
@@ -31,6 +34,7 @@ enum Payload<T> {
 }
 
 /// A blocked request for data, which includes a slot to write the data.
+#[derive(Debug)]
 struct Signal<T> {
     /// Thread to unpark when data is ready.
     thread: Thread,

--- a/src/sync/seg_queue.rs
+++ b/src/sync/seg_queue.rs
@@ -1,5 +1,6 @@
 use std::sync::atomic::Ordering::{Acquire, Release, Relaxed};
 use std::sync::atomic::{AtomicBool, AtomicUsize};
+use std::fmt;
 use std::{ptr, mem};
 use std::cmp;
 use std::cell::UnsafeCell;
@@ -12,6 +13,7 @@ const SEG_SIZE: usize = 32;
 /// for efficiency.
 ///
 /// Usable with any number of producers and consumers.
+#[derive(Debug)]
 pub struct SegQueue<T> {
     head: Atomic<Segment<T>>,
     tail: Atomic<Segment<T>>,
@@ -22,6 +24,12 @@ struct Segment<T> {
     data: [UnsafeCell<(T, AtomicBool)>; SEG_SIZE],
     high: AtomicUsize,
     next: Atomic<Segment<T>>,
+}
+
+impl<T> fmt::Debug for Segment<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Segment {{ ... }}")
+    }
 }
 
 unsafe impl<T: Send> Sync for Segment<T> {}

--- a/src/sync/treiber_stack.rs
+++ b/src/sync/treiber_stack.rs
@@ -6,10 +6,12 @@ use mem::epoch::{self, Atomic, Owned};
 /// Treiber's lock-free stack.
 ///
 /// Usable with any number of producers and consumers.
+#[derive(Debug)]
 pub struct TreiberStack<T> {
     head: Atomic<Node<T>>,
 }
 
+#[derive(Debug)]
 struct Node<T> {
     data: T,
     next: Atomic<Node<T>>,


### PR DESCRIPTION
This commit implements `std::fmt::Debug` for all public types. In most cases,
this was simply adding `#[derive(Debug)]` to the type and the types of its
members. However, there are two exceptions, where `Debug` is implemented
manually because it cannot be derived: (1) `Scope<'a>`, which uses `FnBox` which
is not `Debug`, and (2) `ScopedJoinHandle<T>`, which uses `JoinState` which uses
`std::thread::JoinHandle<T>` which is not `Debug`.

Fixes #62.