### PR TITLE
Use version without patch version in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To use Crossbeam, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-crossbeam = "0.2.5"
+crossbeam = "0.2"
 ```
 
 For examples of what Crossbeam is capable of, see the


### PR DESCRIPTION
So the readme needs less updating as the package evolves.