### PR TITLE
Fix reading uninitialized data in ms_queue

### DIFF
--- a/src/sync/ms_queue.rs
+++ b/src/sync/ms_queue.rs
@@ -63,7 +63,7 @@ impl<T> MsQueue<T> {
             tail: CachePadded::new(Atomic::null()),
         };
         let sentinel = Owned::new(Node {
-            payload: unsafe { mem::uninitialized() },
+            payload: Payload::Data(unsafe { mem::uninitialized() }),
             next: Atomic::null(),
         });
         let guard = epoch::pin();


### PR DESCRIPTION
If you create an `MsQueue` with `MsQueue::new()`, then call `push()`, the first thing that is called is `tail.is_data()`.

This function reads from the value of `tail.payload` whose content is set `mem::uninitialized()` by the `new()` function.

In the tests the content of `tail.payload` ends up being filled with 0s, so there's no problem. In my real-world application though, the enum discriminant that chooses between the enum variants `Payload::Data` and `Payload::Blocked` is `1184` , which leads to a crash.

This PR fixes that so that it no longer crashes. In reality though, the code after the fix is still technically undefined behavior since you're still reading partially uninitialized memory.