### PR TITLE
Relax an acquire load in Chase-Lev deque

### DIFF
--- a/src/sync/chase_lev.rs
+++ b/src/sync/chase_lev.rs
@@ -230,7 +230,7 @@ impl<T> Deque<T> {
     fn steal(&self) -> Steal<T> {
         let guard = epoch::pin();
 
-        let t = self.top.load(Acquire);
+        let t = self.top.load(Relaxed); // the next SeqCst fence is enough.
         fence(SeqCst); // top must be loaded before bottom.
         let b = self.bottom.load(Acquire);
 


### PR DESCRIPTION
A relaxed load followed by an acquire fence is effectively an acquire
load.  This commit relaxes the ordering of an acquire load followed
by an SC fence, into a relaxed load.