### PR TITLE
Fixes ordering bug in ms queue

### DIFF
--- a/src/sync/ms_queue.rs
+++ b/src/sync/ms_queue.rs
@@ -174,7 +174,7 @@ impl<T> MsQueue<T> {
                         unsafe {
                             // signal the thread
                             (*signal).data = Some(cache.into_data());
-                            (*signal).ready.store(true, Relaxed);
+                            (*signal).ready.store(true, Release);
                             (*signal).thread.unpark();
                             guard.unlinked(head);
                             return;
@@ -295,7 +295,7 @@ impl<T> MsQueue<T> {
             // case, blocked.
             match self.push_internal(&guard, tail, node) {
                 Ok(()) => {
-                    while !signal.ready.load(Relaxed) {
+                    while !signal.ready.load(Acquire) {
                         thread::park();
                     }
                     return signal.data.unwrap();


### PR DESCRIPTION
`Signal.ready` is being used to guard access to the data slot. This
requires using acquire / release ordering vs. relaxed.

I believe that the original code was written with the assumption that
`thread::park() / unpark()` was able to provide the necessary ordering,
but this is not true given that park() can spuriously wakeup, which
means that there is a chance (although, a small one) for the memory to
not be in a consistent state.

Fixes #97