### PR TITLE
Don't try to gc except when we have just entered an epoch.

### DIFF
--- a/src/mem/epoch/guard.rs
+++ b/src/mem/epoch/guard.rs
@@ -22,13 +22,13 @@ pub struct Guard {
 /// pinning around the entire set of operations.
 pub fn pin() -> Guard {
     local::with_participant(|p| {
-        p.enter();
+        let entered = p.enter();
 
         let g = Guard {
             _marker: marker::PhantomData,
         };
 
-        if p.should_gc() {
+        if entered && p.should_gc() {
             p.try_collect(&g);
         }
 


### PR DESCRIPTION
This fixes a bug where entering nested epochs could cause the
epoch to advance invalidly. Closes #105.